### PR TITLE
Add missing dep so repo is java 11 compatible

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [ch.qos.logback/logback-classic "1.2.2"]
+                 [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]
                  [org.apache.pdfbox/pdfbox "2.0.12"]
                  [org.apache.pdfbox/preflight "2.0.12"]]
   :main ^:skip-aot pdf-validator.core)


### PR DESCRIPTION
When running pdf-validator with java 11 (e.g. `lein run -- -vv ../form-works/vt_absentee.en.pdf`), an error occurs that doesn't when running in java 8:

`Exception in thread "main" java.lang.NoClassDefFoundError: javax/activation/DataSource, compiling:(pdf_validator/validate.clj:11:24)`

[This error is because the relevant module was removed from the JDK in Java 11](https://www.deps.co/blog/how-to-upgrade-clojure-projects-to-use-java-11/#deprecations). This adds it back as a dep with the most recent version from maven central